### PR TITLE
add option to bypass zone connection data

### DIFF
--- a/EasyFindConfiguration.cpp
+++ b/EasyFindConfiguration.cpp
@@ -253,6 +253,7 @@ void EasyFindConfiguration::ResetSettings()
 	m_coloredFindWindowEnabled = true;
 	m_silentGroupCommands = true;
 	m_verboseMessages = false;
+	m_ignoreZoneConnectionDataEnabled = false;
 
 	m_configNode = YAML::Node();
 	SaveSettings();
@@ -286,6 +287,7 @@ void EasyFindConfiguration::LoadSettings()
 		m_distanceColumnEnabled = m_configNode["DistanceColumn"].as<bool>(true);
 		m_silentGroupCommands = m_configNode["SilentGroupCommands"].as<bool>(true);
 		m_verboseMessages = m_configNode["VerboseMessages"].as<bool>(false);
+		m_ignoreZoneConnectionDataEnabled = m_configNode["IgnoreZoneConnectionData"].as<bool>(false);
 	}
 	catch (const YAML::ParserException& ex)
 	{
@@ -399,6 +401,14 @@ void EasyFindConfiguration::SetVerboseMessages(bool verbose)
 {
 	m_verboseMessages = verbose;
 	m_configNode["VerboseMessages"] = verbose;
+
+	SaveSettings();
+}
+
+void EasyFindConfiguration::SetIgnoreZoneConnectionDataEnabled(bool ignore)
+{
+	m_ignoreZoneConnectionDataEnabled = ignore;
+	m_configNode["IgnoreZoneConnectionData"] = ignore;
 
 	SaveSettings();
 }

--- a/EasyFindConfiguration.h
+++ b/EasyFindConfiguration.h
@@ -70,6 +70,9 @@ public:
 	void SetVerboseMessages(bool verbose);
 	bool IsVerboseMessages() const { return m_verboseMessages; }
 
+	void SetIgnoreZoneConnectionDataEnabled(bool ignore);
+	bool IsIgnoreZoneConnectionDataEnabled() const { return m_ignoreZoneConnectionDataEnabled; }
+
 	// transfer types
 	void RefreshTransferTypes();
 	bool IsSupportedTransferType(int transferTypeIndex) const;
@@ -113,6 +116,7 @@ private:
 	bool m_coloredFindWindowEnabled = true;
 	bool m_silentGroupCommands = true;
 	bool m_verboseMessages = false;
+	bool m_ignoreZoneConnectionDataEnabled = false;
 };
 
 extern EasyFindConfiguration* g_configuration;

--- a/EasyFindImGui.cpp
+++ b/EasyFindImGui.cpp
@@ -810,6 +810,25 @@ void DrawEasyFindSettingsPanel()
 	//----------------------------------------------------------------------------
 	ImGui::NewLine();
 	ImGui::PushFont(imgui::LargeTextFont);
+	ImGui::TextColored(MQColor(255, 255, 0).ToImColor(), "Ignore Zone Connection Data");
+	ImGui::Separator();
+	ImGui::PopFont();
+
+	ImGui::PushStyleColor(ImGuiCol_Text, MQColor(255, 255, 255, 128).ToImU32());
+	ImGui::TextWrapped("Emulated servers may not send zone connection data to the client. In order for EasyFind to continue "
+		"working, this option allows EasyFind to populate connections entirely from ZoneConnections.yaml.");
+	ImGui::PopStyleColor();
+
+	bool isIgnoreZoneConnectionDataEnabled = g_configuration->IsIgnoreZoneConnectionDataEnabled();
+
+	if (ImGui::Checkbox("Ignore Zone Connection Data", &isIgnoreZoneConnectionDataEnabled))
+	{
+		g_configuration->SetIgnoreZoneConnectionDataEnabled(isIgnoreZoneConnectionDataEnabled);
+	}
+
+	//----------------------------------------------------------------------------
+	ImGui::NewLine();
+	ImGui::PushFont(imgui::LargeTextFont);
 	ImGui::TextColored(MQColor(255, 255, 0).ToImColor(), "Zone Guide Transfer Types");
 	ImGui::Separator();
 	ImGui::PopFont();

--- a/EasyFindWindow.cpp
+++ b/EasyFindWindow.cpp
@@ -79,7 +79,7 @@ int CFindLocationWndOverride::OnProcessFrame()
 	UpdateDistanceColumn();
 
 	// Ensure that we wait for spawns to be populated into the spawn map first.
-	if (zoneConnectionsRcvd && !sm_customLocationsAdded && gSpawnCount > 0)
+	if ((zoneConnectionsRcvd || g_configuration->IsIgnoreZoneConnectionDataEnabled()) && !sm_customLocationsAdded && gSpawnCount > 0)
 	{
 		AddCustomLocations(true);
 


### PR DESCRIPTION
Adds a new configuration option to bypass the check for zone connection data received from the server.
Defaults to false.

![image](https://user-images.githubusercontent.com/100880604/199640209-82262774-c5f9-4c8b-84c6-084843b53e5c.png)
