### PR TITLE
Update ZoneConnections.yaml

### DIFF
--- a/resources/EasyFind/ZoneConnections.yaml
+++ b/resources/EasyFind/ZoneConnections.yaml
@@ -786,6 +786,17 @@ FindLocations:
         -   type: ZoneConnection
             targetZone: dragonscale
             remove: true
+    laurioninn:
+        -   type: ZoneConnection
+            switch: 13
+            name: 'Plane of Mischief'
+            location: [-875.93, -88.46, 27.71]
+            targetZone: mischiefplane
+        -   type: ZoneConnection
+            switch: 16
+            name: 'Elddar Forest'
+            location: [-854.78, -166.18, 27.71]
+            targetZone: elddar              
     maiden:
         -   type: ZoneConnection
             location: [-2290, 95, -160]


### PR DESCRIPTION
Laurion Inn doors used for Return of the Kanghammer (Elddar Forest) and Bidils the Quickhand (Plane of Mischief) raid events