### PR TITLE
fix: corrects Natimbi to Nedaria's Landing keyword

### DIFF
--- a/resources/EasyFind/ZoneConnections.yaml
+++ b/resources/EasyFind/ZoneConnections.yaml
@@ -948,7 +948,7 @@ FindLocations:
             destinations:
                 -   keyword: Abysmal Sea
                     targetZone: abysmal
-                -   keyword: Nedaria's Landing
+                -   keyword: Nedaria
                     targetZone: nedaria
         -   type: Translocator
             name: '#Madronoa'


### PR DESCRIPTION
Changes keyword from "Nedaria's Landing" to "Nedaria"