### PR TITLE
RoF_shardslanding-poshadow

### DIFF
--- a/resources/EasyFind/ZoneConnections.yaml
+++ b/resources/EasyFind/ZoneConnections.yaml
@@ -1608,6 +1608,10 @@ FindLocations:
         -   type: ZoneConnection
             switch: 2
             targetZone: poknowledge
+    shardslanding:
+        -   type: ZoneConnection
+            targetZone: poshadow
+            switch: 109
     sharvahl:
         -   type: ZoneConnection
             location: [1680, -470, -212.24]


### PR DESCRIPTION
plane of shadow portal is not on default in game find window nor in mq2easyfind

added switch entry to go to poshadow
