### PR TITLE
Add 'Override' optional functionality to allow an external YAML to en…

### DIFF
--- a/EasyFindZoneConnections.h
+++ b/EasyFindZoneConnections.h
@@ -68,6 +68,7 @@ public:
 	const std::string& GetConfigDir() const { return m_easyfindDir; }
 
 	void Load(std::string_view customFile = {});
+	void LoadOverride(std::string_view customFile);
 	void LoadFindableLocations();
 
 	void ReloadFindableLocations(std::string_view customFile = {});
@@ -83,12 +84,15 @@ public:
 private:
 	std::string m_easyfindDir;
 	YAML::Node m_zoneConnectionsConfig;
+	YAML::Node m_zoneConnectionsOverrideConfig;
 
 	bool m_transferTypesLoaded = false;
 	bool m_zoneDataLoaded = false;
 
 	// Loaded findable locations
 	FindableLocationsMap m_findableLocations;
+
+	void LoadFindableLocations_Internal(YAML::Node zoneConnectionsConfig);
 };
 
 extern ZoneConnections* g_zoneConnections;


### PR DESCRIPTION
Adds optional ability to load ZoneConnections_Override.yaml, should file exist.
Different than "Custom" files which 100% replace the existing ZoneConnections.yaml, this merely adds to the connections already loaded.

This allows us to have a file with our Guild Hall Clicky connections, for example, without having to update it every release.

I have a separate LUA I use (and may publish shortly) which generates just such a ZoneConnections_Override.yaml. 