### PR TITLE
Changed zone connection coordinates for Stone Hive

### DIFF
--- a/resources/EasyFind/ZoneConnections.yaml
+++ b/resources/EasyFind/ZoneConnections.yaml
@@ -943,7 +943,7 @@ FindLocations:
             targetZone: lfaydark
     moors:
         -   type: ZoneConnection
-            location: [-1754, -886, 38]
+            location: [-445, -3772, 163.18]
             targetZone: stonehive
     mseru:
         -   type: ZoneConnection


### PR DESCRIPTION
Stone hive connection from Blightfire Moors seemed to be incorrect as the coordinates were off map.
Previous: -1754, -886, 38.00
Now: -445, -3772, 163.18

