### PR TITLE
Update location coordinates from moors to stone hive

### DIFF
--- a/resources/EasyFind/ZoneConnections.yaml
+++ b/resources/EasyFind/ZoneConnections.yaml
@@ -943,7 +943,7 @@ FindLocations:
             targetZone: lfaydark
     moors:
         -   type: ZoneConnection
-            location: [-1754, -886, 38]
+            location: [-445, -3772, 163.18]
             targetZone: stonehive
     mseru:
         -   type: ZoneConnection


### PR DESCRIPTION
Stone Hive connection from Blightfire Moors was off map, found and edited the proper coords